### PR TITLE
TestShell 버그 수정

### DIFF
--- a/TestShell/testcmd.h
+++ b/TestShell/testcmd.h
@@ -29,10 +29,10 @@ public:
 	void run_cmd(SsdDriver* ssd_driver, vector<string>& args) override {
 		cout << 
 			"write <idx> <value>    Write value to idx'th LBA.\n"\
-			"read <idx>             Print out the value of idx'th LBA.\n";
-			"exit                   Terminate the shell.\n";
-			"help                   Print out the help message.\n";
-			"fullwrite <value>      Write value to all LBAs indexed from 0 to 99.\n";
+			"read <idx>             Print out the value of idx'th LBA.\n"\
+			"exit                   Terminate the shell.\n"\
+			"help                   Print out the help message.\n"\
+			"fullwrite <value>      Write value to all LBAs indexed from 0 to 99.\n"\
 			"fullread <idx>         Print out all values of LBAs indexed from 0 to 99.\n";
 	}
 };

--- a/TestShell/testshell.cpp
+++ b/TestShell/testshell.cpp
@@ -36,6 +36,7 @@ public:
 		auto cmd_runner = get_test_cmd_runner();
 		if (cmd_runner != nullptr) {
 			cmd_runner->run_cmd(ssd_driver, args);
+			delete cmd_runner;
 			return true;
 		}
 

--- a/TestShell_Sample-Test/test.cpp
+++ b/TestShell_Sample-Test/test.cpp
@@ -90,10 +90,10 @@ TEST(TestShell, HelpCmd) {
 
 	string PRINT_OUT_HELP = 
 		"write <idx> <value>    Write value to idx'th LBA.\n"\
-		"read <idx>             Print out the value of idx'th LBA.\n";
-		"exit                   Terminate the shell.\n";
-		"help                   Print out the help message.\n";
-		"fullwrite <value>      Write value to all LBAs indexed from 0 to 99.\n";
+		"read <idx>             Print out the value of idx'th LBA.\n"\
+		"exit                   Terminate the shell.\n"\
+		"help                   Print out the help message.\n"\
+		"fullwrite <value>      Write value to all LBAs indexed from 0 to 99.\n"\
 		"fullread <idx>         Print out all values of LBAs indexed from 0 to 99.\n";
 	EXPECT_THAT(captured_buf.str(), Eq(PRINT_OUT_HELP));
 


### PR DESCRIPTION
다음과 같이 TestShell 내부 버그를 수정하였습니다.

1. 전체 Help 메시지가 정상적으로 출력 되도록 수정
2. TestCmd 사용 후 할당 된 메모리를 해제하도록 수정