### PR TITLE
[feature] add read operation for MockFileIO

### DIFF
--- a/TestShell/FileIoInterface.h
+++ b/TestShell/FileIoInterface.h
@@ -4,6 +4,7 @@
 class FileIoInterface {
 public:
     virtual FILE* Open(const char* filename, const char* mode) = 0;
+    virtual size_t Read(int fd, void* buf, size_t count) = 0;
     virtual size_t Write(const void* data, size_t size, size_t num, FILE* file) = 0;
     virtual int Close(FILE* file) = 0;
 };

--- a/TestShell/testcmd.h
+++ b/TestShell/testcmd.h
@@ -65,3 +65,22 @@ public:
 			ssd_driver->write(idx, stoi(args[0]));
 	}
 };
+
+class FullreadTestCmd : public TestCmd {
+public:
+	void run_cmd(SsdDriver* ssd_driver, FileIoInterface* fio, vector<string>& args) override {
+		ssd_driver->read(stoi(args[0]));
+		FILE* fd = fio->Open(FILE_NAME_NAND, "r");
+		if (fd == nullptr) {
+			throw std::runtime_error("File Open Error");
+		}
+		else {
+			char buf[MAX_BUF_SIZE];
+			memset(buf, 0, MAX_BUF_SIZE);
+			fio->Read((int)fd, buf, ONE_LINE_SIZE);
+		}
+	}
+	static const int ONE_LINE_SIZE = 10;
+	static const int MAX_LINE = 40;
+	static const int MAX_BUF_SIZE = ONE_LINE_SIZE * MAX_LINE;
+};

--- a/TestShell/testcmd.h
+++ b/TestShell/testcmd.h
@@ -23,10 +23,19 @@ class ReadTestCmd : public TestCmd {
 public:
 	void run_cmd(SsdDriver* ssd_driver, FileIoInterface* fio, vector<string>& args) override {
 		ssd_driver->read(stoi(args[0]));
-		if (fio->Open(FILE_NAME_RESULT, "r") == nullptr) {
+		FILE* fd = fio->Open(FILE_NAME_RESULT, "r");
+		if (fd == nullptr) {
 			throw std::runtime_error("File Open Error");
 		}
+		else {
+			char buf[MAX_BUF_SIZE];
+			memset(buf, 0, MAX_BUF_SIZE);
+			fio->Read((int)fd, buf, ONE_LINE_SIZE);
+		}
 	}
+	static const int ONE_LINE_SIZE = 10;
+	static const int MAX_LINE = 40;
+	static const int MAX_BUF_SIZE = ONE_LINE_SIZE * MAX_LINE;
 };
 
 class ExitTestCmd : public TestCmd {

--- a/TestShell/testshell.cpp
+++ b/TestShell/testshell.cpp
@@ -62,6 +62,7 @@ private:
 		if (cmd == TEST_CMD::WRITE && args.size() >= 2 && isValidLbaIndex(args[0]) && isValidWriteValue(args[1])) return;
 		if (cmd == TEST_CMD::READ && args.size() >= 1 && isValidLbaIndex(args[0])) return;
 		if (cmd == TEST_CMD::FULLWRITE && args.size() >= 1 && isValidWriteValue(args[0])) return;
+		if (cmd == TEST_CMD::FULLREAD && args.size() == 0 ) return;
 		if (cmd == TEST_CMD::EXIT) return;
 		if (cmd == TEST_CMD::HELP) return;
 			
@@ -82,6 +83,7 @@ private:
 		if (cmd == TEST_CMD::EXIT) return new ExitTestCmd();
 		if (cmd == TEST_CMD::HELP) return new HelpTestCmd();
 		if (cmd == TEST_CMD::FULLWRITE) return new FullwriteTestCmd();
+		if (cmd == TEST_CMD::FULLREAD) return new FullreadTestCmd();
 		return nullptr;
 	}
 

--- a/TestShell_Sample-Test/MockFileIo.h
+++ b/TestShell_Sample-Test/MockFileIo.h
@@ -8,6 +8,7 @@
 class MockFileIO : public FileIoInterface {
 public:
     MOCK_METHOD(FILE* , Open, (const char* filename, const char* mode), (override));
+    MOCK_METHOD(size_t, Read, (int fd, void* buf, size_t count), (override));
     MOCK_METHOD(size_t, Write, (const void* data,
         size_t size, size_t num, FILE* file), (override));
     MOCK_METHOD(int , Close, (FILE* file), (override));


### PR DESCRIPTION
can read data at mocking

- add MockFileIO::Read()
- add FullreadTestCmd

Test에서 file의 data를 Read할수 있도록 수정하였습니다.

TODO
- ReadTestCmd에서 read한 Data와 실제 Data가 일치하는지 확인 필요.