### PR TITLE
TestShell driver interface 변경

### DIFF
--- a/TestShell/SsdDriver.h
+++ b/TestShell/SsdDriver.h
@@ -1,0 +1,14 @@
+#pragma once
+#include <string>
+
+#define interface struct 
+
+#define FILE_NAME_RESULT "result.txt"
+
+using namespace std;
+
+interface SsdDriver {
+public:
+    virtual void write(unsigned int lba_index, string value) = 0;
+    virtual void read(unsigned int lba_index) = 0;
+};

--- a/TestShell/TestShell.vcxproj
+++ b/TestShell/TestShell.vcxproj
@@ -131,6 +131,7 @@
     <ClCompile Include="testshell.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="SsdDriver.h" />
     <ClInclude Include="testcmd.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/TestShell/TestShell.vcxproj.filters
+++ b/TestShell/TestShell.vcxproj.filters
@@ -26,5 +26,8 @@
     <ClInclude Include="testcmd.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>
+    <ClInclude Include="SsdDriver.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/TestShell/testcmd.h
+++ b/TestShell/testcmd.h
@@ -3,7 +3,7 @@
 #include <vector>
 #include <stdexcept>
 #include <iostream>
-#include "../SSD_Project/SsdDriver.h"
+#include "SsdDriver.h"
 #include "FileIoInterface.h"
 
 using namespace std;
@@ -15,7 +15,7 @@ interface TestCmd {
 class WriteTestCmd : public TestCmd {
 public:
 	void run_cmd(SsdDriver* ssd_driver, FileIoInterface* fio, vector<string>& args) override {
-		ssd_driver->write(stoi(args[0]), stoi(args[1]));
+		ssd_driver->write(stoi(args[0]), args[1]);
 	}
 };
 
@@ -53,6 +53,6 @@ class FullwriteTestCmd : public TestCmd {
 public:
 	void run_cmd(SsdDriver* ssd_driver, FileIoInterface* fio, vector<string>& args) override {
 		for (auto idx = 0; idx < 100; idx++)
-			ssd_driver->write(idx, stoi(args[0]));
+			ssd_driver->write(idx, args[0]);
 	}
 };

--- a/TestShell/testshell.cpp
+++ b/TestShell/testshell.cpp
@@ -2,7 +2,7 @@
 #include <vector>
 #include <stdexcept>
 #include "testcmd.h"
-#include "../SSD_Project/SsdDriver.h"
+#include "SsdDriver.h"
 #include "../TestShell/FileIOInterface.h"
 
 using namespace std;

--- a/TestShell_Sample-Test/MockSsdDriver.h
+++ b/TestShell_Sample-Test/MockSsdDriver.h
@@ -1,9 +1,9 @@
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
-#include "../SSD_Project/SsdDriver.h"
+#include "../TestShell/SsdDriver.h"
 
 class MockSsdDriver : public SsdDriver {
 public:
-	MOCK_METHOD(void, write, (unsigned int lba_index, unsigned int value), (override));
-	MOCK_METHOD(unsigned int, read, (unsigned int lba_index), (override));
+	MOCK_METHOD(void, write, (unsigned int lba_index, string value), (override));
+	MOCK_METHOD(void, read, (unsigned int lba_index), (override));
 };

--- a/TestShell_Sample-Test/test.cpp
+++ b/TestShell_Sample-Test/test.cpp
@@ -4,10 +4,9 @@
 #include <stdio.h>
 #include <stdexcept>
 
-#include "../SSD_Project/SsdDriver.h"
-
 #include "MockSsdDriver.h"
 #include "MockFileIo.h"
+#include "../TestShell/SsdDriver.h"
 #include "../TestShell/testshell.cpp"
 
 using namespace std;
@@ -69,8 +68,7 @@ TEST_F(SSDFixture, ReadCmdSuccess) {
 		.WillRepeatedly(Return(test_file));
 
 	EXPECT_CALL(mock_ssd, read(_))
-		.Times(1)
-		.WillRepeatedly(Return(READ_SUCCESS));
+		.Times(1);
 
 	mock_ssd.read(0x00);
 	FILE* result_file = mfio.Open(FILE_NAME_RESULT, "w");
@@ -86,8 +84,7 @@ TEST_F(SSDFixture, ReadCmdFail) {
 		.WillRepeatedly(Return(test_file));
 
 	EXPECT_CALL(mock_ssd, read(_))
-		.Times(1)
-		.WillRepeatedly(Return(READ_SUCCESS));
+		.Times(1);
 
 	mock_ssd.read(0x00);
 	FILE* result_file = mfio.Open("fail.txt", "r");
@@ -103,8 +100,7 @@ TEST_F(SSDFixture, ReadCmdTestShellSuccess) {
 		.WillRepeatedly(Return(test_file));
 
 	EXPECT_CALL(mock_ssd, read(_))
-		.Times(1)
-		.WillRepeatedly(Return(READ_SUCCESS));
+		.Times(1);
 
 	TestShell ts{ "read", { "0",}, &mock_ssd, &mfio };
 
@@ -120,8 +116,7 @@ TEST_F(SSDFixture, ReadCmdTestShellFail) {
 		.WillRepeatedly(Return(nullptr));
 
 	EXPECT_CALL(mock_ssd, read(_))
-		.Times(1)
-		.WillRepeatedly(Return(READ_SUCCESS));
+		.Times(1);
 
 	TestShell ts{ "read", { "0",}, &mock_ssd, &mfio };
 	EXPECT_THROW(ts.run_cmd(), std::runtime_error);


### PR DESCRIPTION
프로젝트 요구 사항을 반영하여 driver interface 를 정리하는 PR 입니다.
dev/ssd 의 SsdDriver.h 와 동일한 방향으로 수정되었고, 
또한 main branch 로 병합할 때 conflict 을 예방하기 위해 우선 TestShell 프로젝트 내부로 헤더 파일을 새로 생성했습니다.

수정 내용
1. read 기능의 return 을 void 로 변경
2. write 의 value 를 string 으로 변경