### PR TITLE
Hide FileManager constructor into private. Only expose in pulbic when testing

### DIFF
--- a/SSD_Project/FileManager.h
+++ b/SSD_Project/FileManager.h
@@ -9,7 +9,9 @@ using namespace std;
 
 class FileManager {
 public:
+#ifdef __TEST__
     FileManager();
+#endif
     static FileManager& getInstance() {
         static FileManager instance;
         return instance;
@@ -18,6 +20,9 @@ public:
     virtual void readNand(unsigned int line);
 
 private:
+#ifndef __TEST__
+    FileManager();
+#endif
     FileManager& operator=(const FileManager& otherInstance) = delete;
     FileManager(const FileManager& otherInstance) = delete;
     void createFile();

--- a/Sample-Test1/test.cpp
+++ b/Sample-Test1/test.cpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
+#define __TEST__
 #include "../SSD_Project/Ssd.cpp"
 #include "../SSD_Project/CommandManager.cpp"
 #include "../SSD_Project/FileManager.cpp"


### PR DESCRIPTION
FileManager는 singleton 패턴이기 때문에 생성자를 private으로 내리고 
Mock testing할 때는 이렇게 하니까 에러가 나서 testing할 때만 pulbic으로 올리기 위해 define 전처리기 사용 