### PR TITLE
TestShell read / fullread 버그 수정 및 리팩토링

### DIFF
--- a/TestShell/RealFileIo.cpp
+++ b/TestShell/RealFileIo.cpp
@@ -16,7 +16,7 @@ FILE* RealFileIo::Open(const char* filename, const char* mode)
 
 size_t RealFileIo::Read(int fd, void* buf, size_t count)
 {
-    if (_read(fd, buf, count) == -1) {
+    if (_read(fd, buf, (unsigned int)count) == -1) {
         return 0;
     }
 

--- a/TestShell/RealFileIo.cpp
+++ b/TestShell/RealFileIo.cpp
@@ -1,4 +1,5 @@
 #include <stdexcept>
+#include <io.h>
 #include "RealFileIo.h"
 
 using namespace std;
@@ -15,13 +16,9 @@ FILE* RealFileIo::Open(const char* filename, const char* mode)
 
 size_t RealFileIo::Read(int fd, void* buf, size_t count)
 {
-    FILE* file = _fdopen(fd, "r");
-    if (file == nullptr) {
-        throw runtime_error("failed to load file");
+    if (_read(fd, buf, count) == -1) {
+        return 0;
     }
-
-    fgets((char*)buf, count, file);
-    fclose(file);
 
     return count;
 }

--- a/TestShell/RealSsdDriver.cpp
+++ b/TestShell/RealSsdDriver.cpp
@@ -2,7 +2,7 @@
 #include <stdexcept>
 #include "RealSsdDriver.h"
 
-#define SSD_EXECUTABLE "ssd.exe"
+#define SSD_EXECUTABLE "SSD.exe"
 
 void RealSsdDriver::write(unsigned int lba_index, string value)
 {

--- a/TestShell/testcmd.h
+++ b/TestShell/testcmd.h
@@ -82,7 +82,7 @@ public:
 			else {
 				char buf[MAX_BUF_SIZE];
 				memset(buf, 0, MAX_BUF_SIZE);
-				int result = fio->Read(_fileno(fd), buf, ONE_LINE_SIZE);
+				auto result = fio->Read(_fileno(fd), buf, ONE_LINE_SIZE);
 				buf[ONE_LINE_SIZE] = 0;
 				fclose(fd);
 				if (result == 0) return;
@@ -91,7 +91,7 @@ public:
 		}
 
 	}
-	static const int ONE_LINE_SIZE = 10;
+	static const size_t ONE_LINE_SIZE = 10;
 	static const int MAX_LINE = 100;
 	static const int MAX_BUF_SIZE = ONE_LINE_SIZE * MAX_LINE;
 };

--- a/TestShell/testcmd.h
+++ b/TestShell/testcmd.h
@@ -31,7 +31,9 @@ public:
 		else {
 			char buf[MAX_BUF_SIZE];
 			memset(buf, 0, MAX_BUF_SIZE);
-			fio->Read((int)fd, buf, ONE_LINE_SIZE);
+			fio->Read(_fileno(fd), buf, ONE_LINE_SIZE);
+			buf[ONE_LINE_SIZE] = 0;
+			fclose(fd);
 			std::cout << buf;
 		}
 	}
@@ -80,10 +82,11 @@ public:
 			else {
 				char buf[MAX_BUF_SIZE];
 				memset(buf, 0, MAX_BUF_SIZE);
-				int result = fio->Read((int)fd, buf, ONE_LINE_SIZE);
+				int result = fio->Read(_fileno(fd), buf, ONE_LINE_SIZE);
+				buf[ONE_LINE_SIZE] = 0;
+				fclose(fd);
 				if (result == 0) return;
 				std::cout << buf;
-				if (fd) fclose(fd);
 			}
 		}
 

--- a/TestShell_Sample-Test/test.cpp
+++ b/TestShell_Sample-Test/test.cpp
@@ -126,7 +126,7 @@ TEST_F(TestShellFixture, ReadCmdTestShellSuccess) {
 	EXPECT_CALL(mfio, Open(testing::StrEq(FILE_NAME_RESULT), _))
 		.WillRepeatedly(Return(test_file));
 
-	EXPECT_CALL(mfio, Read((int)test_file, _, _))
+	EXPECT_CALL(mfio, Read(_, _, _))
 		.WillOnce(::testing::Invoke([&](int fd, void* buf, size_t count) {
 		memcpy(buf, result.c_str(), count);
 		return count;
@@ -218,7 +218,7 @@ TEST_F(TestShellFixture, FullReadCmd) {
 		.WillRepeatedly(Return(test_file));
 
 
-	EXPECT_CALL(mfio, Read((int)test_file, _, _))
+	EXPECT_CALL(mfio, Read(_, _, _))
 		.WillRepeatedly(::testing::Invoke([&](int fd, void* buf, size_t count) {
 			memset(buf, 0, count);
 			memcpy(buf, result.c_str(), count);
@@ -263,7 +263,7 @@ TEST_F(TestShellFixture, TestApp1Cmd) {
 		.WillRepeatedly(Return(test_file));
 
 
-	EXPECT_CALL(mfio, Read((int)test_file, _, _))
+	EXPECT_CALL(mfio, Read(_, _, _))
 		.WillRepeatedly(::testing::Invoke([&](int fd, void* buf, size_t count) {
 		memset(buf, 0, count);
 		memcpy(buf, result.c_str(), count);
@@ -299,7 +299,7 @@ TEST_F(TestShellFixture, TestApp2Cmd) {
 		.WillRepeatedly(Return(test_file));
 
 
-	EXPECT_CALL(mfio, Read((int)test_file, _, _))
+	EXPECT_CALL(mfio, Read(_, _, _))
 		.WillRepeatedly(::testing::Invoke([&](int fd, void* buf, size_t count) {
 		memset(buf, 0, count);
 		memcpy(buf, result.c_str(), count);


### PR DESCRIPTION
1. RealFileIo 를 사용하여 read / fullread 사용 시 Crash 나는 버그 수정
2. TestShell 빌드 시 발생하는 Warning 제거