### PR TITLE
[feature] add flush at testshell

### DIFF
--- a/TestShell/testcmd.h
+++ b/TestShell/testcmd.h
@@ -222,3 +222,10 @@ public:
 		EraseTestCmd{}.run_cmd(ssd_driver, fio, actual_args);
 	}
 };
+
+class FlushTestCmd : public TestCmd {
+public:
+	void run_cmd(SsdDriver* ssd_driver, FileIoInterface* fio, vector<string>& args) override {
+		ssd_driver->flush();
+	}
+};

--- a/TestShell/testshell.cpp
+++ b/TestShell/testshell.cpp
@@ -25,6 +25,7 @@ namespace TEST_CMD {
 	const string TESTAPP2 = "testapp2";
 	const string ERASE = "erase";
 	const string ERASERANGE = "erase_range";
+	const string FLUSH = "flush";
 }
 
 class TestShell {
@@ -105,7 +106,7 @@ private:
 		auto allowed_cmds = {
 			TEST_CMD::WRITE, TEST_CMD::READ, TEST_CMD::EXIT, TEST_CMD::HELP,
 			TEST_CMD::FULLWRITE, TEST_CMD::FULLREAD, TEST_CMD::TESTAPP1, TEST_CMD::TESTAPP2,
-			TEST_CMD::ERASE, TEST_CMD::ERASERANGE
+			TEST_CMD::ERASE, TEST_CMD::ERASERANGE, TEST_CMD::FLUSH
 		};
 		for (auto& cmd : allowed_cmds) {
 			if (this->cmd == cmd) return;
@@ -130,7 +131,8 @@ private:
 				})) return;
 		}
 		if (cmd == TEST_CMD::ERASERANGE && args.size() >= 2 && isValidEraseRangeArgs()) return;
-			
+		if (cmd == TEST_CMD::FLUSH && args.size() == 0) return;
+
 		throw invalid_argument("WRONG ARGUMENT");
 	}
 
@@ -177,6 +179,7 @@ private:
 		if (cmd == TEST_CMD::TESTAPP2) return new TestApp2TestCmd();
 		if (cmd == TEST_CMD::ERASE) return new EraseTestCmd();
 		if (cmd == TEST_CMD::ERASERANGE) return new EraseRangeTestCmd();
+		if (cmd == TEST_CMD::FLUSH) return new FlushTestCmd();
 		return nullptr;
 	}
 


### PR DESCRIPTION
testshell에서 flush를 할수 있는 command를 추가합니다.

EXAMPLE :
====================================
TestShell> write 3 0xAAAABBBB

$ cat nand.txt
0x00000000
0x00000000
0x00000000
0x00000000
0x00000000

TestShell> flush

$ cat nand.txt
0x00000000
0x00000000
0x00000000
0xAAAABBBB
0x00000000
0x00000000