### PR TITLE
[bugfix] remove setRedirection() from SsdDriver

### DIFF
--- a/TestShell/RealSsdDriver.h
+++ b/TestShell/RealSsdDriver.h
@@ -1,12 +1,13 @@
+#pragma once
 #include "SsdDriver.h"
 
 class RealSsdDriver : public SsdDriver {
 public:
 	void write(unsigned int lba_index, string value) override;
 	void read(unsigned int lba_index) override;
-	void setRedirection(bool redirection) override;
 	void erase(unsigned int lba_index, unsigned int size) override;
 	void flush() override;
+	void setRedirection(bool redirection);
 
 private:
 	void execute_cmd(string& execute_cmd, string error_msg);

--- a/TestShell/Runner.cpp
+++ b/TestShell/Runner.cpp
@@ -21,7 +21,7 @@ public:
             if (len > 0 && command[len - 1] == '\n') {
                 command[len - 1] = '\0';
             }
-            ts->setDriverRedirection(true);
+            setDriverRedirection(ts->getDriver(), true);
             if(run_scenario(ts, command) != 0){
                 break;
             }
@@ -44,6 +44,15 @@ public:
     }
 
 private:
+    void setDriverRedirection(SsdDriver* driver, bool isReDirection) {
+        RealSsdDriver* realDriver = dynamic_cast<RealSsdDriver*>(driver);
+        if (realDriver != nullptr) {
+            realDriver->setRedirection(isReDirection);
+        }
+        else {
+            std::cout << "The driver is not a RealSsdDriver" << std::endl;
+        }
+    }
     void LOG(string str) {
         set_oringin_std_inout();
         std::cout << str;

--- a/TestShell/testshell.cpp
+++ b/TestShell/testshell.cpp
@@ -38,9 +38,10 @@ public:
 		this->ssd_driver = driver;
 	}
 
-	void setDriverRedirection(bool isReDirection) {
-		ssd_driver->setRedirection(isReDirection);
+	SsdDriver* getDriver() {
+		return ssd_driver;
 	}
+
 	void setFileIo(FileIoInterface* fio) {
 		this->fio = fio;
 	}

--- a/TestShell_Sample-Test/MockSsdDriver.h
+++ b/TestShell_Sample-Test/MockSsdDriver.h
@@ -6,7 +6,6 @@ class MockSsdDriver : public SsdDriver {
 public:
 	MOCK_METHOD(void, write, (unsigned int lba_index, string value), (override));
 	MOCK_METHOD(void, read, (unsigned int lba_index), (override));
-	MOCK_METHOD(void, setRedirection, (bool redirection), (override));
 	MOCK_METHOD(void, erase, (unsigned int lba_index, unsigned int size), (override));
 	MOCK_METHOD(void, flush, (), (override));
 };


### PR DESCRIPTION
- move setRedirection to Runner class

ssdDriver에서 setRedirection()을 삭제하고 RealSsdDriver()로 구현 레벨을 내립니다.
setDriverRedirection을 Runner로 이동합니다.