### PR TITLE
disable Logger std output

### DIFF
--- a/Logger/Logger.cpp
+++ b/Logger/Logger.cpp
@@ -3,8 +3,10 @@
 
 void Logger::printLog(string logMsg, const char functionName[]) {
 	string logEntry = getLogEntry(logMsg, functionName);
+#if (ENABLE_STDOUT)
 	// test scenario에서 cout 출력 buffer를 변경하므로 cout 대신 printf 사용
 	printf(logEntry.c_str());	// cout << logEntry;
+#endif
 	try {
 		logFileManager.recordLogOnFile(logEntry, timeManager.getFileNameForStore());
 	}

--- a/Logger/Logger.h
+++ b/Logger/Logger.h
@@ -7,9 +7,11 @@
 using namespace std;
 
 #ifdef __TEST__
-#define ENABLE_LOG	(0)
+#define ENABLE_LOG		(0)
+#define ENABLE_STDOUT	(0 & ENABLE_LOG)
 #else
-#define ENABLE_LOG	(1)
+#define ENABLE_LOG		(1)
+#define ENABLE_STDOUT	(0 & ENABLE_LOG)
 #endif
 
 #if (ENABLE_LOG)


### PR DESCRIPTION
Runner 동작 시 Log가 화면에 출력되면 안되므로 Logger std output을 빌드 옵션으로 바꿀 수 있게 하였고 default는 disable로 수정했습니다.